### PR TITLE
incorporated line hierarchy

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -5,6 +5,7 @@ import copy
 import pre_process as pp
 import parse_name as pn
 
+
 class coordinate:
     x = 0
     y = 0
@@ -13,35 +14,41 @@ class coordinate:
         self.x = x
         self.y = y
 
+
 class boundingBox:
     bound_text = ''
-    tl = coordinate(0,0)
-    tr = coordinate(0,0)
-    br = coordinate(0,0)
-    bl = coordinate(0,0)
+    box_type = ''
+    tl = coordinate(0, 0)
+    tr = coordinate(0, 0)
+    br = coordinate(0, 0)
+    bl = coordinate(0, 0)
 
-    def __init__(self, tl, tr, bl, br, bound_text):
-        
+    def __init__(self, tl, tr, bl, br, bound_text, box_type):
+
         """
         :param tl: coordinates of top left
         :param tr: coordinates of top right
         :param bl: coordinates of bottom left
         :param br: coordinates of bottom right
+        :param bound_text: The text inside the box
+        :param box_type: catagorize the boxx as line(L)/word(W)
         """
-        
+
         self.tl = tl
         self.tr = tr
         self.br = br
         self.bl = bl
         self.bound_text = bound_text
+        self.box_type = box_type
 
-    def __repr__(self): #object definition
-        return "<boundingBox bound_text:%s tl:(%s,%s) tr:(%s,%s) bl:(%s,%s) br:(%s,%s)>" %(self.bound_text,self.tl.x,self.tl.y,
-            self.tr.x,self.tr.y,self.bl.x,self.bl.y,self.br.x,self.br.y)
+    def __repr__(self):  # object definition
+        return "<boundingBox box_type:%s bound_text:%s tl:(%s,%s) tr:(%s,%s) bl:(%s,%s) br:(%s,%s)>" %(self.box_type, self.bound_text, self.tl.x, self.tl.y, 
+            self.tr.x, self.tr.y, self.bl.x, self.bl.y, self.br.x, self.br.y)
 
-    def __str__(self): #print statement
-        return "bound_text:%s \n tl:(%s,%s) \n tr:(%s,%s) \n bl:(%s,%s) \n br:(%s,%s)" %(self.bound_text,self.tl.x,self.tl.y,
-            self.tr.x,self.tr.y,self.bl.x,self.bl.y,self.br.x,self.br.y)
+    def __str__(self):  # print statement
+        return "box_type:%s \nbound_text:%s \ntl:(%s,%s) \ntr:(%s,%s) \nbl:(%s,%s) \nbr:(%s,%s)" %(self.box_type, self.bound_text, self.tl.x, self.tl.y, 
+            self.tr.x, self.tr.y, self.bl.x, self.bl.y, self.br.x, self.br.y)
+
 
 def preprocess(input_image):
     """
@@ -67,6 +74,7 @@ def get_azure_ocr(input_image):
     azure_json = {}
     return azure_json
 
+
 def parse_azure_json(azure_json):
     """
     extract data from json created by Azure
@@ -76,42 +84,56 @@ def parse_azure_json(azure_json):
 
     data = json.load(open(azure_json))
     sentence = data["recognitionResult"]["lines"]
-    l = len(sentence)
+    slen = len(sentence)
 
-    #initialize
-    c = coordinate(0,0)
-    bb = boundingBox(c,c,c,c,"")
+    # initialize
+    c = coordinate(0, 0)
+    bb = boundingBox(c, c, c, c, "", "W")
     llist = []
-    for i in range(l):
-        line = data["recognitionResult"]["lines"][i]["words"]
+    for i in range(slen):
+        line = sentence[i]["words"]
+        line_box = sentence[i]["boundingBox"]
+        bb.bound_text = sentence[i]["text"]
+        bb.box_type = "L"
+        bb.bl = coordinate(line_box[0], line_box[1])
+        bb.br = coordinate(line_box[2], line_box[3])
+        bb.tr = coordinate(line_box[4], line_box[5])
+        bb.tl = coordinate(line_box[6], line_box[7])
+        llist.append(copy.deepcopy(bb))
         llen = len(line)
         for j in range(llen):
             word_box = line[j]["boundingBox"]
             word = line[j]["text"]
-            bb.bl = coordinate(word_box[0],word_box[1])
-            bb.br = coordinate(word_box[2],word_box[3])
-            bb.tr = coordinate(word_box[4],word_box[5])
-            bb.tl = coordinate(word_box[6],word_box[7])
+            bb.box_type = "W"
+            bb.bl = coordinate(word_box[0], word_box[1])
+            bb.br = coordinate(word_box[2], word_box[3])
+            bb.tr = coordinate(word_box[4], word_box[5])
+            bb.tl = coordinate(word_box[6], word_box[7])
             bb.bound_text = word
             llist.append(copy.deepcopy(bb))
     return llist
+
 
 def get_parallel_boxes(bounding_boxes):
     list_of_boxes = []
     return list_of_boxes
 
+
 def get_lexigram(bounding_boxes):
     lexigram_json = {}
     return lexigram_json
+
 
 def fix_spelling(bounding_box):
     # return bounding box
     return bounding_box
 
+
 def replace_image_with_text(input_image, list_of_bounding_boxes):
     in_image = cv2.imread(input_image)
     out_image = in_image
     return out_image
+
 
 if __name__ == '__main__':
     print("Hello!")


### PR DESCRIPTION
With reference to issue #14 .
Added Flag `W/L`  {currently I have kept these as strings but can be changed to boolean if required}

New object type:
```python
<boundingBox box_type:L bound_text:DD FORM 1289 tl:(206,40) tr:(324,36) bl:(205,18) br:(323,15)>  # for line
<boundingBox box_type:W bound_text:DD tl:(195,44) tr:(233,42) bl:(193,21) br:(231,19)>  # for box
```
Output type:
```python
# for line
box_type:L 
bound_text:DD FORM 1289 
tl:(206,40) 
tr:(324,36) 
bl:(205,18) 
br:(323,15)

# for box
box_type:W 
bound_text:DD 
tl:(195,44) 
tr:(233,42) 
bl:(193,21) 
br:(231,19)

```
Hierarchy is as such  in the list :`LWWWWLWW...` This indicates that each Line is followed by the words contained in that line and so on.